### PR TITLE
MP-844: Legg til konstanter for å telje auth_details_type

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+SAK:
+ID-xxxx
+
+Sjekklister:  
+Eigar:
+
+- [ ] Vurdert breaking changes
+- [ ] Avhengigheter til andre saker avklart
+- [ ] Testet mot en eller flere tjenester som bruker biblioteket
+- [ ] Unngått å legge til unødvendige avhengigheter
+- [ ] Har oppdatert dependabots
+
+Kodeles:
+
+- [ ] Lesbar kode, nødvendige kommentarer
+- [ ] Sak er godt nok forklart/dokumentert
+- [ ] Løyser saka
+- [ ] Har oppdatert readme 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,6 @@ Sjekklister:
 Eigar:
 
 - [ ] Vurdert breaking changes
-- [ ] Avhengigheter til andre saker avklart
-- [ ] Testet mot en eller flere tjenester som bruker biblioteket
 - [ ] Unngått å legge til unødvendige avhengigheter
 - [ ] Har oppdatert dependabots
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.0</version>
+                <version>3.14.1</version>
                 <configuration>
                     <source>${maven.compiler.release}</source>
                     <target>${maven.compiler.release}</target>

--- a/src/main/java/no/idporten/metric/constants/MetricCategories.java
+++ b/src/main/java/no/idporten/metric/constants/MetricCategories.java
@@ -7,4 +7,5 @@ public class MetricCategories {
         public final static String EID = "eid";
         public final static String OIDC_INTEGRATION = "oidc_integration";
         public final static String DETAILS = "details";
+        public final static String AUTHORIZATIONDETAILS_TYPE = "authorizationdetails_type";
 }

--- a/src/main/java/no/idporten/metric/constants/MetricDescriptions.java
+++ b/src/main/java/no/idporten/metric/constants/MetricDescriptions.java
@@ -8,5 +8,6 @@ public class MetricDescriptions {
     public final static String APP_EXCEPTION_EXTERNAL_API_DESCRIPTION = "Counter for API connection problems from application to external API";
     public final static String APP_EXCEPTION_GENERIC_DESCRIPTION = "Counter for connection problems from application to somewhere else";
     public final static String APP_OIDC_OPERATION_DESCRIPTION = "Counter for oidc operations";
+    public final static String APP_AUTHORIZATIONDETAILS_TYPE_DESCRIPTION = "Counter requests for each AuthorizationDetails Type, type in details tag";
 
 }


### PR DESCRIPTION
SAK:
MP-844: Legg til konstanter for å telje auth_details_type


Sjekklister:  
Eigar:

- [x] Vurdert breaking changes
- [x] Unngått å legge til unødvendige avhengigheter
- [x] Har oppdatert dependabots

Kodeles:

- [x] Lesbar kode, nødvendige kommentarer
- [x] Sak er godt nok forklart/dokumentert
- [x] Løyser saka
- [x] Har oppdatert readme 